### PR TITLE
Group achievement progress by type and move to grouped relational storage

### DIFF
--- a/mmorpg.sql
+++ b/mmorpg.sql
@@ -325,7 +325,7 @@ CREATE TABLE `tw_accounts_data` (
   `WeekStamp` bigint(20) NOT NULL DEFAULT 0,
   `MonthStamp` bigint(20) NOT NULL DEFAULT 0,
   `Upgrade` int(11) NOT NULL DEFAULT 0,
-  `Achievements` longtext NOT NULL DEFAULT '',
+  `Achievements` longtext NOT NULL DEFAULT '' COMMENT 'deprecated',
   PRIMARY KEY (`ID`),
   UNIQUE KEY `Nick` (`Nick`),
   KEY `tw_accounts_data_ibfk_3` (`WorldID`),
@@ -334,6 +334,26 @@ CREATE TABLE `tw_accounts_data` (
   CONSTRAINT `tw_accounts_data_ibfk_5` FOREIGN KEY (`ID`) REFERENCES `tw_accounts` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `tw_accounts_data_ibfk_6` FOREIGN KEY (`ProfessionID`) REFERENCES `enum_professions` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tw_accounts_achievements`
+--
+
+DROP TABLE IF EXISTS `tw_accounts_achievements`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `tw_accounts_achievements` (
+  `AccountID` int(11) NOT NULL,
+  `AchievementType` int(11) NOT NULL,
+  `Criteria` int(11) NOT NULL,
+  `Progress` int(11) NOT NULL DEFAULT 0,
+  `CompletedLevel` int(11) NOT NULL DEFAULT 0,
+  `UpdatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY `AccountAchievement` (`AccountID`,`AchievementType`,`Criteria`),
+  KEY `AccountID` (`AccountID`),
+  CONSTRAINT `tw_accounts_achievements_ibfk_1` FOREIGN KEY (`AccountID`) REFERENCES `tw_accounts_data` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/src/game/server/core/components/accounts/account_data.h
+++ b/src/game/server/core/components/accounts/account_data.h
@@ -17,6 +17,7 @@ class CHouse;
 class GroupData;
 class CGuild;
 class CGuildMemberData;
+class CAchievementInfo;
 
 class CAccountData
 {
@@ -34,7 +35,6 @@ class CAccountData
 	std::weak_ptr<GroupData> m_pGroupData;
 	CGuild* m_pGuildData{};
 	CProfession* m_pActiveProfession {};
-	nlohmann::json m_AchievementsData { };
 	BonusManager m_BonusManager{};
 	PrisonManager m_PrisonManager{};
 	BigInt m_Bank {};
@@ -178,9 +178,8 @@ public:
 	void HandleChair(int Level);
 
 	// Achievements
-	void InitAchievements(const std::string& Data);
-	void UpdateAchievementProgress(int AchievementID, int Progress, bool Completed);
-	nlohmann::json& GetAchievementsData() { return m_AchievementsData; }
+	void InitAchievements();
+	void UpdateAchievementProgress(const CAchievementInfo* pInfo, int Progress, bool Completed);
 
 	// Aethers
 	bool IsUnlockedAether(int AetherID) const { return m_aAetherLocation.find(AetherID) != m_aAetherLocation.end(); }

--- a/src/game/server/core/components/achievements/achievement_data.cpp
+++ b/src/game/server/core/components/achievements/achievement_data.cpp
@@ -90,7 +90,7 @@ bool CAchievement::UpdateProgress(int Criteria, int Progress, int ProgressType)
 	}
 
 	// save
-	pPlayer->Account()->UpdateAchievementProgress(m_pInfo->GetID(), m_Progress, m_Completed);
+	pPlayer->Account()->UpdateAchievementProgress(m_pInfo, m_Progress, m_Completed);
 	return true;
 }
 

--- a/src/game/server/core/components/achievements/achievement_data.h
+++ b/src/game/server/core/components/achievements/achievement_data.h
@@ -76,6 +76,9 @@ class CAchievement : public MultiworldIdentifiableData< std::map< int, std::dequ
 	int m_Progress {};
 	bool m_Completed {};
 	bool m_NotifiedSoonComplete {};
+	int m_LastSavedProgress {};
+	bool m_LastSavedCompleted {};
+	int m_LastSaveTick {};
 
 public:
 	explicit CAchievement(CAchievementInfo* pInfo, int ClientID) : m_pInfo(pInfo), m_ClientID(ClientID) {}
@@ -90,6 +93,9 @@ public:
 	{
 		m_Progress = Progress;
 		m_Completed = Completed;
+		m_LastSavedProgress = Progress;
+		m_LastSavedCompleted = Completed;
+		m_LastSaveTick = 0;
 	}
 
 	CAchievementInfo* Info() const { return m_pInfo; }

--- a/src/game/server/core/components/achievements/achievement_listener.cpp
+++ b/src/game/server/core/components/achievements/achievement_listener.cpp
@@ -75,8 +75,6 @@ void CAchievementListener::UpdateAchievement(CPlayer* pPlayer, AchievementType T
 	if(!pPlayer || pPlayer->IsBot())
 		return;
 
-	// initialize variables
-	bool Updated = false;
 	auto& pAchievements = CAchievement::Data()[pPlayer->GetCID()];
 
 	// search for the achievement
@@ -90,14 +88,7 @@ void CAchievementListener::UpdateAchievement(CPlayer* pPlayer, AchievementType T
 
 		if(achievementCriteria <= 0 || achievementCriteria == Criteria)
 		{
-			if(pAchievement->UpdateProgress(Criteria, Progress, ProgressType))
-				Updated = true;
+			pAchievement->UpdateProgress(Criteria, Progress, ProgressType);
 		}
-	}
-
-	// update the achievement progress in the database
-	if(Updated)
-	{
-		pPlayer->GS()->Core()->SaveAccount(pPlayer, SAVE_ACHIEVEMENTS);
 	}
 }

--- a/src/game/server/core/mmo_context.h
+++ b/src/game/server/core/mmo_context.h
@@ -76,7 +76,6 @@ enum ESaveType
 	SAVE_POSITION,          // Save Position Player
 	SAVE_LANGUAGE,          // Save Language Client
 	SAVE_TIME_PERIODS,      // Save Time Periods
-	SAVE_ACHIEVEMENTS,      // Save Achievements
 };
 
 // world day types

--- a/src/game/server/core/mmo_controller.cpp
+++ b/src/game/server/core/mmo_controller.cpp
@@ -441,13 +441,6 @@ void CMmoController::SaveAccount(CPlayer* pPlayer, int Table) const
 		Database->Execute<DB::UPDATE>("tw_accounts_data", "DailyStamp = '{}', WeekStamp = '{}', MonthStamp = '{}' WHERE ID = '{}'", Daily, Week, Month, AccountID);
 	}
 
-	// save achievements
-	else if(Table == SAVE_ACHIEVEMENTS)
-	{
-		const auto AchievementsData = pAccount->GetAchievementsData().dump();
-		Database->Execute<DB::UPDATE>("tw_accounts_data", "Achievements = '{}' WHERE ID = '{}'", AchievementsData, AccountID);
-	}
-
 	// save language
 	else if(Table == SAVE_LANGUAGE)
 	{


### PR DESCRIPTION
### Motivation
- Store achievements that come in level series (e.g. `PVE 1.1`, `PVE 1.2`, ...) as grouped rows so higher levels are recorded as a completed-level marker instead of many per-achievement rows.
- Remove the legacy per-account JSON achievements blob and reduce whole-blob races by persisting grouped progress atomically.
- Reduce DB churn by grouping progress by `(AchievementType, Criteria)` and optimize queries for initialization and updates.
- Simplify runtime listeners to rely on per-achievement persistence instead of triggering full-account saves.

### Description
- Schema: replaced the previous `tw_accounts_achievements` layout with columns `(AccountID, AchievementType, Criteria, Progress, CompletedLevel, UpdatedAt)` and a unique key on `(AccountID, AchievementType, Criteria)`, and marked the `tw_accounts_data.Achievements` column as deprecated in `mmorpg.sql`.
- Initialization: `CAccountData::InitAchievements()` now queries `tw_accounts_achievements` for grouped rows, maps `(AchievementType, Criteria) -> (Progress, CompletedLevel)`, and hydrates each `CAchievement` with clamped progress and a completion flag derived from `CompletedLevel` or required progress.
- Persistence: changed `CAccountData::UpdateAchievementProgress` to accept a `const CAchievementInfo*` and perform an `INSERT ... ON DUPLICATE KEY UPDATE` upsert that updates `Progress` and uses `GREATEST(CompletedLevel, new)` to preserve the highest completed level for the group.
- Cleanup: updated call sites to pass `CAchievementInfo*` (e.g. `CAchievement::UpdateProgress` now calls `UpdateAchievementProgress(pInfo, ...)`), removed the `SAVE_ACHIEVEMENTS` save path and the listener-triggered full-account save for achievements.

### Testing
- No automated tests were executed for this change.
- Basic static edits and compilation were performed via repository changes (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bbff48288327977e538b93742b12)