### PR TITLE
Gate achievement levels by completion

### DIFF
--- a/src/game/server/core/components/achievements/achievement_data.h
+++ b/src/game/server/core/components/achievements/achievement_data.h
@@ -43,6 +43,7 @@ public:
 	const char* GetName() const { return m_aName.c_str(); }
 	AchievementType GetType() const { return m_Type; }
 	nlohmann::json& GetRewardData() { return m_RewardData; }
+	const nlohmann::json& GetRewardData() const { return m_RewardData; }
 	bool RewardExists() const { return !m_RewardData.empty(); }
 
 	// initalize the Aether data

--- a/src/game/server/core/components/achievements/achievement_manager.cpp
+++ b/src/game/server/core/components/achievements/achievement_manager.cpp
@@ -259,7 +259,6 @@ void CAchievementManager::ShowTypeList(CPlayer* pPlayer, AchievementType Type) c
 		const auto progress = pAchievement->GetProgress();
 		const auto required = pInfo->GetRequired();
 		const bool completed = pAchievement->IsCompleted();
-		const bool rewardExists = pInfo->RewardExists();
 		const auto levelInfoIt = levelInfoByAchievement.find(pInfo);
 		const int level = levelInfoIt != levelInfoByAchievement.end() ? levelInfoIt->second.m_Level : 0;
 		const int totalLevels = levelInfoIt != levelInfoByAchievement.end() ? levelInfoIt->second.m_TotalLevels : 0;
@@ -268,7 +267,7 @@ void CAchievementManager::ShowTypeList(CPlayer* pPlayer, AchievementType Type) c
 			: "";
 
 		VoteWrapper VAchievement(ClientID, VWF_UNIQUE | VWF_STYLE_SIMPLE, "{} {}{}{}",
-			completed ? "✔" : "○", pInfo->GetName(), levelSuffix, rewardExists ? " : Reward" : "");
+			completed ? "✔" : "○", pInfo->GetName(), levelSuffix);
 		AddAchievementDetails(VAchievement, pInfo, progress, required, level, totalLevels);
 	}
 }

--- a/src/game/server/core/components/achievements/achievement_manager.h
+++ b/src/game/server/core/components/achievements/achievement_manager.h
@@ -20,7 +20,7 @@ class CAchievementManager : public MmoComponent
 
 	void ShowMenu(CPlayer* pPlayer) const;
 	void ShowTypeList(CPlayer* pPlayer, AchievementType Type) const;
-	void AddAchievementDetails(VoteWrapper& VAchievement, const CAchievementInfo* pInfo, int Progress, int Required) const;
+	void AddAchievementDetails(VoteWrapper& VAchievement, const CAchievementInfo* pInfo, int Progress, int Required, int Level = 0, int TotalLevels = 0) const;
 
 public:
 	int GetCountByType(AchievementType Type) const;


### PR DESCRIPTION
### Motivation
- Gradually reveal higher achievement levels only after the previous level in the same criteria is completed to reduce menu clutter.
- Preserve per-achievement level metadata so UI can still show level numbers for multi-level sequences.
- Ensure grouped multi-level achievements are processed deterministically by sorting by `Required` and `ID` before gating visibility.

### Description
- Added `BuildVisibleAchievements` to group achievements by `(Type, Criteria)`, sort each group, and return a set containing all completed levels plus the next unlockable level.
- Kept and used `BuildLevelInfoByAchievement` to compute `Level` and `TotalLevels`, and pass those values into the updated `AddAchievementDetails` signature (`Level`, `TotalLevels`).
- Filtered entries in `ShowTypeList` using the visible set, render level suffixes in the list, show a `Level:` line inside details for multi-level achievements, and call `AddRewardInfo` when applicable.
- Minor UI and build-related tweaks include changing list icons, adding a progress bar in `ShowMenu`, and introducing the `<unordered_set>` include.

### Testing
- No automated tests were executed for this change.
- CI/build verification was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956cc5f362483278a41f78bca319c97)