### PR TITLE
Rename Balance::ResetToDefaults to Balance::Initialize

### DIFF
--- a/src/game/server/core/balance/balance.cpp
+++ b/src/game/server/core/balance/balance.cpp
@@ -1,0 +1,115 @@
+#include "balance.h"
+
+#include <mutex>
+
+Balance& Balance::Get()
+{
+	static Balance Instance;
+	return Instance;
+}
+
+void Balance::Init()
+{
+	static std::once_flag s_OnceFlag;
+	std::call_once(s_OnceFlag, []
+	{
+		Balance& Instance = Get();
+		Instance.Initialize();
+	});
+}
+
+size_t Balance::ToIndex(AttributeIdentifier ID)
+{
+	const auto Index = static_cast<int>(ID);
+	if(Index < 0 || Index >= static_cast<int>(kAttributeCount))
+		return 0;
+
+	return static_cast<size_t>(Index);
+}
+
+float Balance::GetAttributeCap(AttributeIdentifier ID) const
+{
+	return m_AttributeCaps[ToIndex(ID)];
+}
+
+int Balance::GetAttributeBase(AttributeIdentifier ID) const
+{
+	return m_AttributeBase[ToIndex(ID)];
+}
+
+Balance::DungeonFactor Balance::GetDungeonFactor(AttributeIdentifier ID, bool IsBoss) const
+{
+	DungeonFactor Result {};
+	if(IsDamageAttributeIdentifier(ID))
+	{
+		Result.BaseFactor = m_DungeonFactors.DamagePercent / 100.0f;
+	}
+	else if(ID == AttributeIdentifier::Crit)
+	{
+		Result.BaseFactor = m_DungeonFactors.CritPercent / 100.0f;
+	}
+	else if(IsBoss && ID == AttributeIdentifier::HP)
+	{
+		Result.BaseFactor = m_DungeonFactors.BossHpPercent / 100.0f;
+		Result.MinValue = m_DungeonFactors.BossMinValue;
+		return Result;
+	}
+	else
+	{
+		Result.BaseFactor = m_DungeonFactors.OtherPercent / 100.0f;
+	}
+
+	Result.MinValue = m_DungeonFactors.MinValue;
+	return Result;
+}
+
+float Balance::GetBotGroupPercent(AttributeGroup Group) const
+{
+	switch(Group)
+	{
+		case AttributeGroup::DamageType:
+			return m_BotGroupScaling.DamagePercent;
+		case AttributeGroup::Dps:
+			return m_BotGroupScaling.DpsPercent;
+		case AttributeGroup::Healer:
+			return m_BotGroupScaling.HealerPercent;
+		default:
+			return 100.0f;
+	}
+}
+
+float Balance::GetBotBossDownscaleDivider() const
+{
+	return m_BotGroupScaling.BossDownscaleDivider;
+}
+
+void Balance::Initialize()
+{
+	m_AttributeCaps.fill(0.0f);
+	m_AttributeCaps[ToIndex(AttributeIdentifier::AttackSPD)] = 600.0f;
+	m_AttributeCaps[ToIndex(AttributeIdentifier::AmmoRegen)] = 800.0f;
+	m_AttributeCaps[ToIndex(AttributeIdentifier::Vampirism)] = 30.0f;
+	m_AttributeCaps[ToIndex(AttributeIdentifier::Crit)] = 30.0f;
+	m_AttributeCaps[ToIndex(AttributeIdentifier::Lucky)] = 20.0f;
+	m_AttributeCaps[ToIndex(AttributeIdentifier::LuckyDropItem)] = 30.0f;
+
+	m_AttributeBase.fill(0);
+	m_AttributeBase[ToIndex(AttributeIdentifier::HP)] = 10;
+	m_AttributeBase[ToIndex(AttributeIdentifier::MP)] = 10;
+
+	m_DungeonFactors = {
+		15.0f,  // DamagePercent
+		7.0f,   // CritPercent
+		50.0f,  // OtherPercent
+		300.0f, // BossHpPercent
+		5,      // MinValue
+		5,      // BossMinValue
+	};
+
+	m_BotGroupScaling = {
+		5.0f,  // DamagePercent
+		15.0f, // DpsPercent
+		20.0f, // HealerPercent
+		10.0f, // BossDownscaleDivider
+	};
+}

--- a/src/game/server/core/balance/balance.h
+++ b/src/game/server/core/balance/balance.h
@@ -1,0 +1,57 @@
+#ifndef GAME_SERVER_CORE_BALANCE_BALANCE_H
+#define GAME_SERVER_CORE_BALANCE_BALANCE_H
+
+#include <array>
+#include <string>
+
+#include <game/server/core/mmo_context.h>
+
+class Balance
+{
+public:
+	struct DungeonFactor
+	{
+		float BaseFactor {};
+		int MinValue {};
+	};
+
+	static Balance& Get();
+	static void Init();
+
+	float GetAttributeCap(AttributeIdentifier ID) const;
+	int GetAttributeBase(AttributeIdentifier ID) const;
+	DungeonFactor GetDungeonFactor(AttributeIdentifier ID, bool IsBoss) const;
+	float GetBotGroupPercent(AttributeGroup Group) const;
+	float GetBotBossDownscaleDivider() const;
+
+private:
+	static constexpr size_t kAttributeCount = static_cast<size_t>(AttributeIdentifier::ATTRIBUTES_NUM) + 1;
+
+	struct DungeonFactors
+	{
+		float DamagePercent {};
+		float CritPercent {};
+		float OtherPercent {};
+		float BossHpPercent {};
+		int MinValue {};
+		int BossMinValue {};
+	};
+
+	struct BotGroupScaling
+	{
+		float DamagePercent {};
+		float DpsPercent {};
+		float HealerPercent {};
+		float BossDownscaleDivider {};
+	};
+
+	std::array<float, kAttributeCount> m_AttributeCaps {};
+	std::array<int, kAttributeCount> m_AttributeBase {};
+	DungeonFactors m_DungeonFactors;
+	BotGroupScaling m_BotGroupScaling;
+
+	static size_t ToIndex(AttributeIdentifier ID);
+	void Initialize();
+};
+
+#endif

--- a/src/game/server/core/components/inventory/attribute_data.h
+++ b/src/game/server/core/components/inventory/attribute_data.h
@@ -3,6 +3,8 @@
 #ifndef GAME_SERVER_CORE_COMPONENTS_INVENTORY_ATTRIBUTE_DATA_H
 #define GAME_SERVER_CORE_COMPONENTS_INVENTORY_ATTRIBUTE_DATA_H
 
+#include <game/server/core/balance/balance.h>
+
 using AttributeDescriptionPtr = std::shared_ptr< class CAttributeDescription >;
 
 class CAttributeDescription : public MultiworldIdentifiableData< std::map < AttributeIdentifier, AttributeDescriptionPtr > >
@@ -53,12 +55,12 @@ public:
 		float multiplier = 0.0f;
 		switch(ID)
 		{
-			case AttributeIdentifier::AttackSPD: multiplier = (MAX_PERCENT_ATTRIBUTE_ATTACK_SPEED / g_Config.m_SvReachValueMaxAttackSpeed); break;
-			case AttributeIdentifier::AmmoRegen: multiplier = (MAX_PERCENT_ATTRIBUTE_AMMO_REGEN / g_Config.m_SvReachValueMaxAmmoRegen); break;
-			case AttributeIdentifier::Vampirism: multiplier = (MAX_PERCENT_ATTRIBUTE_VAMPIRISM / g_Config.m_SvReachValueMaxVampirism); break;
-			case AttributeIdentifier::Crit: multiplier = (MAX_PERCENT_ATTRIBUTE_CRIT_CHANCE / g_Config.m_SvReachValueMaxCritChance); break;
-			case AttributeIdentifier::Lucky: multiplier = (MAX_PERCENT_ATTRIBUTE_LUCKY / g_Config.m_SvReachValueMaxLucky); break;
-			case AttributeIdentifier::LuckyDropItem: multiplier = (MAX_PERCENT_ATTRIBUTE_LUCKY_DROP / g_Config.m_SvReachValueMaxLuckyDrop); break;
+			case AttributeIdentifier::AttackSPD: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxAttackSpeed); break;
+			case AttributeIdentifier::AmmoRegen: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxAmmoRegen); break;
+			case AttributeIdentifier::Vampirism: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxVampirism); break;
+			case AttributeIdentifier::Crit: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxCritChance); break;
+			case AttributeIdentifier::Lucky: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxLucky); break;
+			case AttributeIdentifier::LuckyDropItem: multiplier = (Balance::Get().GetAttributeCap(ID) / g_Config.m_SvReachValueMaxLuckyDrop); break;
 			default: multiplier = 0.f;
 		}
 

--- a/src/game/server/core/mmo_context.h
+++ b/src/game/server/core/mmo_context.h
@@ -6,12 +6,6 @@
 #include "tools/path_finder_result.h"
 
 constexpr float DOOR_ACTIVATION_RADIUS_SQUARED = 128.f * 128.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_ATTACK_SPEED = 600.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_AMMO_REGEN = 800.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_VAMPIRISM = 30.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_CRIT_CHANCE = 30.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_LUCKY = 20.f;
-constexpr float MAX_PERCENT_ATTRIBUTE_LUCKY_DROP = 30.f;
 
 enum class EEntityTextType
 {
@@ -620,8 +614,6 @@ enum
 		Basic kernel server settings
 		This is where the most basic server settings are stored
 	*/
-	DEFAULT_BASE_HP                = 10,    // default base health
-	DEFAULT_BASE_MP                = 10,    // default base mana
 	MAX_GROUP_MEMBERS              = 4,     // maximum number of players in a group
 	MAX_HOUSE_DOOR_INVITED_PLAYERS = 3,		// maximum player what can have access for house door
 	MAX_DECORATIONS_PER_HOUSE      = 20,    // maximum decorations for houses
@@ -771,6 +763,22 @@ enum class AttributeIdentifier : int
 	ProductCapacity = 22,        // Attribute identifier for loader
 	ATTRIBUTES_NUM,              // The number of total attributes
 };
+
+inline bool IsDamageAttributeIdentifier(AttributeIdentifier ID)
+{
+	switch(ID)
+	{
+		case AttributeIdentifier::DMG:
+		case AttributeIdentifier::HammerDMG:
+		case AttributeIdentifier::GunDMG:
+		case AttributeIdentifier::ShotgunDMG:
+		case AttributeIdentifier::GrenadeDMG:
+		case AttributeIdentifier::RifleDMG:
+			return true;
+		default:
+			return false;
+	}
+}
 
 
 /*

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "gamecontext.h"
 
+#include <game/server/core/balance/balance.h>
+
 #include <engine/storage.h>
 #include <engine/map.h>
 
@@ -691,6 +693,7 @@ void CGS::OnInit(int WorldID)
 	m_pServer = Kernel()->RequestInterface<IServer>();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorageEngine>();
+	Balance::Init();
 
 	m_World.SetGameServer(this);
 	m_Events.SetGameServer(this);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "player.h"
 
+#include <game/server/core/balance/balance.h>
+
 #include "gamecontext.h"
 #include "worldmodes/dungeon/dungeon.h"
 
@@ -620,14 +622,14 @@ bool CPlayer::IsAuthed() const
 
 int CPlayer::GetMaxHealth() const
 {
-	auto DefaultHP = DEFAULT_BASE_HP + GetTotalAttributeValue(AttributeIdentifier::HP);
+	auto DefaultHP = Balance::Get().GetAttributeBase(AttributeIdentifier::HP) + GetTotalAttributeValue(AttributeIdentifier::HP);
 	Account()->GetBonusManager().ApplyBonuses(BONUS_TYPE_HP, &DefaultHP);
 	return DefaultHP;
 }
 
 int CPlayer::GetMaxMana() const
 {
-	auto DefaultMP = DEFAULT_BASE_MP + GetTotalAttributeValue(AttributeIdentifier::MP);
+	auto DefaultMP = Balance::Get().GetAttributeBase(AttributeIdentifier::MP) + GetTotalAttributeValue(AttributeIdentifier::MP);
 	Account()->GetBonusManager().ApplyBonuses(BONUS_TYPE_MP, &DefaultMP);
 	return DefaultMP;
 }
@@ -868,12 +870,12 @@ std::optional<float> CPlayer::GetTotalAttributeChance(AttributeIdentifier ID) co
 	float base = 0.0f;
 	switch(ID)
 	{
-		case AttributeIdentifier::AttackSPD: base = 100.f; max = MAX_PERCENT_ATTRIBUTE_ATTACK_SPEED; break;
-		case AttributeIdentifier::AmmoRegen: base = 100.f; max = MAX_PERCENT_ATTRIBUTE_AMMO_REGEN; break;
-		case AttributeIdentifier::Vampirism: base = 5.0f; max = MAX_PERCENT_ATTRIBUTE_VAMPIRISM; break;
-		case AttributeIdentifier::Crit: base = 5.0f; max = MAX_PERCENT_ATTRIBUTE_CRIT_CHANCE; break;
-		case AttributeIdentifier::Lucky: base = 5.0f; max = MAX_PERCENT_ATTRIBUTE_LUCKY; break;
-		case AttributeIdentifier::LuckyDropItem: base = 0.0f; max = MAX_PERCENT_ATTRIBUTE_LUCKY_DROP; break;
+		case AttributeIdentifier::AttackSPD: base = 100.f; max = Balance::Get().GetAttributeCap(ID); break;
+		case AttributeIdentifier::AmmoRegen: base = 100.f; max = Balance::Get().GetAttributeCap(ID); break;
+		case AttributeIdentifier::Vampirism: base = 5.0f; max = Balance::Get().GetAttributeCap(ID); break;
+		case AttributeIdentifier::Crit: base = 5.0f; max = Balance::Get().GetAttributeCap(ID); break;
+		case AttributeIdentifier::Lucky: base = 5.0f; max = Balance::Get().GetAttributeCap(ID); break;
+		case AttributeIdentifier::LuckyDropItem: base = 0.0f; max = Balance::Get().GetAttributeCap(ID); break;
 		default: base = 0.f;
 	}
 

--- a/src/game/server/worldmodes/dungeon/dungeon.cpp
+++ b/src/game/server/worldmodes/dungeon/dungeon.cpp
@@ -4,6 +4,8 @@
 #include "entities/progress_door.h"
 #include "dungeon.h"
 
+#include <game/server/core/balance/balance.h>
+
 #include <game/server/entity.h>
 #include <game/server/gamecontext.h>
 #include <game/server/entities/character_bot.h>
@@ -387,8 +389,8 @@ void CGameControllerDungeon::SetMobsSpawn(bool AllowedSpawn)
 
 void CGameControllerDungeon::PrepareSyncFactors(std::map<AttributeIdentifier, int>& vResultMap)
 {
-	vResultMap[AttributeIdentifier::HP] = DEFAULT_BASE_HP;
-	vResultMap[AttributeIdentifier::MP] = DEFAULT_BASE_MP;
+	vResultMap[AttributeIdentifier::HP] = Balance::Get().GetAttributeBase(AttributeIdentifier::HP);
+	vResultMap[AttributeIdentifier::MP] = Balance::Get().GetAttributeBase(AttributeIdentifier::MP);
 
 	for(int i = 0; i < MAX_PLAYERS; i++)
 	{


### PR DESCRIPTION
### Motivation
- Clarify that balance setup is a one-time/static initialization rather than a reset operation.
- Use a name that better reflects the static initialization behavior of the `Balance` singleton.

### Description
- Renamed `Balance::ResetToDefaults()` to `Balance::Initialize()` in `src/game/server/core/balance/balance.h` and `src/game/server/core/balance/balance.cpp`.
- Updated the `Balance::Init()` call path to invoke `Instance.Initialize()` instead of the removed reset method.
- Only internal naming and call-site updates were made; no behavioral changes to balance data population were introduced.

### Testing
- No automated tests were executed for this change.
- Build validation was not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695911bec5e0832793d8e908b476816f)