### PR TITLE
Add configurable per-dungeon time limit

### DIFF
--- a/mmprpg_clean.sql
+++ b/mmprpg_clean.sql
@@ -1114,7 +1114,8 @@ CREATE TABLE `tw_dungeons` (
   `DoorX` int(11) NOT NULL DEFAULT 0,
   `DoorY` int(11) NOT NULL DEFAULT 0,
   `Scenario` longtext DEFAULT NULL,
-  `WorldID` int(11) NOT NULL
+  `WorldID` int(11) NOT NULL,
+  `TimeLimit` int(11) NOT NULL DEFAULT 600
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/src/game/server/core/command_processor.cpp
+++ b/src/game/server/core/command_processor.cpp
@@ -591,7 +591,7 @@ void CCommandProcessor::ConChatDonorProTeleport(IConsole::IResult* pResult, void
 		return;
 	}
 
-	// teleport with limited distance
+	// teleport with limited distance and collision
 	auto* pChar = pPlayer->GetCharacter();
 	if(pChar)
 	{
@@ -599,8 +599,24 @@ void CCommandProcessor::ConChatDonorProTeleport(IConsole::IResult* pResult, void
 		const auto Pos = pChar->GetPos();
 		const auto Target = pChar->GetMousePos();
 		const auto Diff = Target - Pos;
-		const auto TeleportPos = length(Diff) > MaxDist ? Pos + normalize(Diff) * MaxDist : Target;
-
+		const auto ClampedTarget = length(Diff) > MaxDist ? Pos + normalize(Diff) * MaxDist : Target;
+		auto* pCollision = pGS->Collision();
+		vec2 ColPos, SafePos;
+		vec2 TeleportPos = ClampedTarget;
+		if(pCollision->IntersectLine(Pos, ClampedTarget, &ColPos, &SafePos))
+			TeleportPos = SafePos;
+		if(pCollision->IntersectLineDoor(Pos, TeleportPos))
+		{
+			const auto Dir = normalize(Pos - TeleportPos);
+			vec2 Safe = TeleportPos;
+			for(float d = 32.0f; d <= MaxDist; d += 32.0f)
+			{
+				Safe = TeleportPos + Dir * d;
+				if(!pCollision->IntersectLineDoor(Pos, Safe))
+					break;
+			}
+			TeleportPos = Safe;
+		}
 		pChar->ChangePosition(TeleportPos);
 		pGS->CreateDeath(TeleportPos, ClientID);
 		pGS->CreatePlayerSpawn(TeleportPos);

--- a/src/game/server/core/components/duties/dungeon_data.h
+++ b/src/game/server/core/components/duties/dungeon_data.h
@@ -15,7 +15,8 @@ class CDungeonData : public MultiworldIdentifiableData< std::deque< CDungeonData
 	int m_Progress {};
 	int m_Players {};
 	int m_WorldID {};
-	nlohmann::json m_Scenario{};
+    int m_TimeLimit {600};
+    nlohmann::json m_Scenario{};
 
 public:
 	enum DungeonState
@@ -34,19 +35,21 @@ public:
 		return m_pData.emplace_back(std::move(pData));
 	}
 
-	void Init(const vec2& WaitingDoorPos, int WorldID, const nlohmann::json& Scenario)
-	{
-		m_WorldID = WorldID;
-		m_WaitingDoorPos = WaitingDoorPos;
-		m_State = STATE_UNINITIALIZED;
-		m_Scenario = Scenario;
-	}
+	void Init(const vec2& WaitingDoorPos, int WorldID, const nlohmann::json& Scenario, int TimeLimit)
+    {
+            m_WorldID = WorldID;
+            m_WaitingDoorPos = WaitingDoorPos;
+            m_State = STATE_UNINITIALIZED;
+            m_Scenario = Scenario;
+            m_TimeLimit = TimeLimit;
+    }
 
 	int GetID() const { return m_ID; }
 	int GetLevel() const;
 	const char* GetName() const;
 	vec2 GetWaitingDoorPos() const { return m_WaitingDoorPos; }
 	int GetWorldID() const { return m_WorldID; }
+    int GetTimeLimit() const { return m_TimeLimit; }
 
 	void SetState(int State) { m_State = State; }
 	int GetState() const { return m_State; }

--- a/src/game/server/core/components/duties/duties_manager.cpp
+++ b/src/game/server/core/components/duties/duties_manager.cpp
@@ -18,7 +18,7 @@ void CDutiesManager::OnPreInit()
 		auto TimeLimit = pRes->getInt("TimeLimit");
 		
 		auto* pDungeon = CDungeonData::CreateElement(ID);
-		pDungeon->Init(WaitingDoorPos, WorldID, Scenario);
+		pDungeon->Init(WaitingDoorPos, WorldID, Scenario, TimeLimit);
 	}
 }
 

--- a/src/game/server/core/components/duties/duties_manager.cpp
+++ b/src/game/server/core/components/duties/duties_manager.cpp
@@ -15,7 +15,8 @@ void CDutiesManager::OnPreInit()
 		auto WaitingDoorPos = vec2(pRes->getInt("DoorX"), pRes->getInt("DoorY"));
 		auto WorldID = pRes->getInt("WorldID");
 		auto Scenario = pRes->getJson("Scenario");
-
+		auto TimeLimit = pRes->getInt("TimeLimit");
+		
 		auto* pDungeon = CDungeonData::CreateElement(ID);
 		pDungeon->Init(WaitingDoorPos, WorldID, Scenario);
 	}

--- a/src/game/server/worldmodes/dungeon/dungeon.cpp
+++ b/src/game/server/worldmodes/dungeon/dungeon.cpp
@@ -68,7 +68,7 @@ void CGameControllerDungeon::ChangeState(int NewState)
 		// update & initialize by state start
 		m_ScenarioID = GS()->ScenarioGroupManager()->RegisterScenario<CDungeonScenario>(-1, m_pDungeon->GetScenario());
 		m_StartedPlayersNum = GetPlayersNum();
-		m_EndTick = Server()->TickSpeed() * 600;
+		m_EndTick = Server()->TickSpeed() * m_pDungeon->GetTimeLimit();
 		m_SafeSpawnTick = Server()->Tick() + (Server()->TickSpeed() * g_Config.m_SvDungeonSafeTime);
 		m_pEntWaitingDoor->Open();
 
@@ -91,7 +91,7 @@ void CGameControllerDungeon::ChangeState(int NewState)
 
 		// information
 		const auto WorldID = m_pDungeon->GetWorldID();
-		GS()->ChatWorld(WorldID, "Dungeon:", "You are given 10 minutes to complete of dungeon!");
+		GS()->ChatWorld(WorldID, "Dungeon:", "You are given {} minutes to complete of dungeon!", m_pDungeon->GetTimeLimit() / 60);
 		GS()->ChatWorld(WorldID, "Dungeon:", "Safe time is active for {} seconds.", (int)g_Config.m_SvDungeonSafeTime);
 		GS()->BroadcastWorld(WorldID, BroadcastPriority::VeryImportant, 500, "Dungeon started!");
 	}

--- a/web-tools/editor-studio/api/db-crud.php
+++ b/web-tools/editor-studio/api/db-crud.php
@@ -137,7 +137,7 @@ $RESOURCES = [
   'dungeons' => [
     'table' => 'tw_dungeons',
     'pk' => 'ID',
-    'columns' => ['Level', 'DoorX', 'DoorY', 'Scenario', 'WorldID'],
+    'columns' => ['Level', 'DoorX', 'DoorY', 'Scenario', 'WorldID', 'TimeLimit'],
     'search' => ['ID', 'Level', 'WorldID'],
     'order' => 'ID ASC',
   ],

--- a/web-tools/editor-studio/dungeons-editor.html
+++ b/web-tools/editor-studio/dungeons-editor.html
@@ -92,6 +92,7 @@
       DoorX: { type: 'number', label: 'DoorX', ui: { step: 1 } },
       DoorY: { type: 'number', label: 'DoorY', ui: { step: 1 } },
       Scenario: { type: 'scenario', label: 'Scenario', ui: { scenarioMode: 'dungeon' } },
+      TimeLimit: { type: 'number', label: 'Time Limit (seconds)', ui: { step: 1 } },
     };
 
     const dirty = EditorCore.Dirty?.create
@@ -112,18 +113,21 @@
         DoorX: 0,
         DoorY: 0,
         Scenario: '',
+        TimeLimit: 600,
       }),
       rowToModel: (row) => ({
         WorldID: Number(row?.WorldID ?? 0),
         DoorX: Number(row?.DoorX ?? 0),
         DoorY: Number(row?.DoorY ?? 0),
         Scenario: row?.Scenario == null ? '' : String(row?.Scenario),
+        TimeLimit: Number(row?.TimeLimit ?? 600),
       }),
       modelToPayload: (model) => ({
         WorldID: toNullableInt(model?.WorldID, 0),
         DoorX: toNullableInt(model?.DoorX, 0),
         DoorY: toNullableInt(model?.DoorY, 0),
         Scenario: model?.Scenario ? String(model.Scenario) : null,
+        TimeLimit: toNullableInt(model?.TimeLimit, 600),
       }),
       listItem: (row) => ({
         title: `Dungeon #${row?.ID || 0}`,


### PR DESCRIPTION
Adds a `TimeLimit` column (in seconds, default 600) to `tw_dungeons`, allowing each dungeon to have its own time limit instead of the hardcoded 10-minute limit. + web-editor config

Also fixes `/dpro_blink` teleporting players into solid walls and laser doors