### PR TITLE
feat: add donor bridge visibility toggle and improve bridge mute system

### DIFF
--- a/src/game/server/core/command_processor.cpp
+++ b/src/game/server/core/command_processor.cpp
@@ -1,4 +1,4 @@
-﻿#include "command_processor.h"
+#include "command_processor.h"
 
 #include <engine/server.h>
 #include <game/server/core/components/accounts/account_manager.h>
@@ -57,6 +57,8 @@ CCommandProcessor::CCommandProcessor(CGS* pGS)
 	AddCommand("donor_pro", "", ConChatDonorProCmdList, pServer, "Donor pro command list");
 	AddCommand("dpro_blink", "", ConChatDonorProTeleport, pServer, "Donor Pro teleport to view point");
 	AddCommand("rainbow", "i[mode]", ConChatRainbow, pServer, "Update rainbow mode skin effect (Donor)");
+	AddCommand("bridge_disable", "", ConChatBridgeDisable, pServer, "Hide your messages from Discord bridge (Donor)");
+	AddCommand("bridge_enable", "", ConChatBridgeEnable, pServer, "Show your messages on Discord bridge (Donor)");
 
 	// other
 	AddCommand("timeout", "?s[code]", ConChatTimeoutGuest, pServer, "Timeout auth code");
@@ -518,6 +520,8 @@ void CCommandProcessor::ConChatDonorCmdList(IConsole::IResult* pResult, void* pU
 	if(pDonorItem->GetExpiresAt() > 0)
 		pGS->Chat(ClientID, "Left time: {}", pDonorItem->GetExpiresRemainingString());
 	pGS->Chat(ClientID, "/rainbow - Rainbow skin effect.");
+	pGS->Chat(ClientID, "/bridge_disable - Hide your messages from Discord.");
+	pGS->Chat(ClientID, "/bridge_enable - Show your messages on Discord again.");
 }
 
 void CCommandProcessor::ConChatDonorProCmdList(IConsole::IResult* pResult, void* pUser)
@@ -541,6 +545,8 @@ void CCommandProcessor::ConChatDonorProCmdList(IConsole::IResult* pResult, void*
 		pGS->Chat(ClientID, "Left time: {}", pDonorProItem->GetExpiresRemainingString());
 	pGS->Chat(ClientID, "/dpro_blink - teleport to view point.");
 	pGS->Chat(ClientID, "/rainbow - Rainbow skin effect.");
+	pGS->Chat(ClientID, "/bridge_disable - Hide your messages from Discord.");
+	pGS->Chat(ClientID, "/bridge_enable - Show your messages on Discord again.");
 }
 
 void CCommandProcessor::ConChatRainbow(IConsole::IResult* pResult, void* pUser)
@@ -639,6 +645,50 @@ void CCommandProcessor::ConChatDonorProTeleport(IConsole::IResult* pResult, void
 		}
 }
 
+
+void CCommandProcessor::ConChatBridgeDisable(IConsole::IResult* pResult, void* pUser)
+{
+	const int ClientID = pResult->GetClientID();
+	auto* pGS = GetCommandResultGameServer(ClientID, pUser);
+	auto* pPlayer = pGS->GetPlayer(ClientID);
+	if(!is_valid_player(pGS, pPlayer, true))
+		return;
+
+	// check privileges valid
+	const auto* pDonorItem = pPlayer->GetItem(itDonor);
+	const auto* pDonorProItem = pPlayer->GetItem(itDonorPro);
+	if(!pDonorItem->HasItem() && !pDonorProItem->HasItem())
+	{
+		pGS->Chat(ClientID, "Bridge visibility is a {}, {} feature.", pDonorItem->Info()->GetName(), pDonorProItem->Info()->GetName());
+		return;
+	}
+
+	// signal bridge to suppress this player's messages
+	pGS->Console()->PrintFormat(IConsole::OUTPUT_LEVEL_STANDARD, "bridge", "[BRIDGE_DISABLE] %s", pGS->Server()->ClientName(ClientID));
+	pGS->Chat(ClientID, "Your messages will no longer appear on Discord.");
+}
+
+void CCommandProcessor::ConChatBridgeEnable(IConsole::IResult* pResult, void* pUser)
+{
+	const int ClientID = pResult->GetClientID();
+	auto* pGS = GetCommandResultGameServer(ClientID, pUser);
+	auto* pPlayer = pGS->GetPlayer(ClientID);
+	if(!is_valid_player(pGS, pPlayer, true))
+		return;
+
+	// check privileges valid
+	const auto* pDonorItem = pPlayer->GetItem(itDonor);
+	const auto* pDonorProItem = pPlayer->GetItem(itDonorPro);
+	if(!pDonorItem->HasItem() && !pDonorProItem->HasItem())
+	{
+		pGS->Chat(ClientID, "Bridge visibility is a {}, {} feature.", pDonorItem->Info()->GetName(), pDonorProItem->Info()->GetName());
+		return;
+	}
+
+	// signal bridge to restore this player's messages
+	pGS->Console()->PrintFormat(IConsole::OUTPUT_LEVEL_STANDARD, "bridge", "[BRIDGE_ENABLE] %s", pGS->Server()->ClientName(ClientID));
+	pGS->Chat(ClientID, "Your messages will now appear on Discord again.");
+}
 
 void CCommandProcessor::ConChatTimeoutGuest(IConsole::IResult* pResult, void* pUser)
 {

--- a/src/game/server/core/command_processor.h
+++ b/src/game/server/core/command_processor.h
@@ -27,7 +27,9 @@ class CCommandProcessor
 	static void ConChatDonorCmdList(IConsole::IResult* pResult, void* pUserData);
 	static void ConChatDonorProCmdList(IConsole::IResult* pResult, void* pUserData);
 	static void ConChatDonorProTeleport(IConsole::IResult* pResult, void* pUserData);
-    static void ConChatRainbow(IConsole::IResult* pResult, void* pUserData);
+	static void ConChatRainbow(IConsole::IResult* pResult, void* pUserData);
+	static void ConChatBridgeDisable(IConsole::IResult* pResult, void* pUserData);
+	static void ConChatBridgeEnable(IConsole::IResult* pResult, void* pUserData);
 	static void ConChatTimeoutGuest(IConsole::IResult* pResult, void* pUserData);
 
 	static void ConChatPlaceholder(IConsole::IResult* pResult, void* pUserData);

--- a/src/game/server/core/components/guilds/guild_manager.cpp
+++ b/src/game/server/core/components/guilds/guild_manager.cpp
@@ -73,7 +73,7 @@ void CGuildManager::OnTick()
 		}
 
 		// update guild houses rent expiration each 15 minutes
-		if(Server()->Tick() % Server()->TickSpeed() * 900 == 0)
+		if(Server()->Tick() % (Server()->TickSpeed() * 900) == 0)
 		{
 			for(auto& pGuild : CGuild::Data())
 			{

--- a/src/game/server/core/components/houses/house_manager.cpp
+++ b/src/game/server/core/components/houses/house_manager.cpp
@@ -36,7 +36,7 @@ void CHouseManager::OnTick()
 	if(GS()->GetWorldID() == INITIALIZER_WORLD_ID)
 	{
 		// update houses rent expiration each 15 minutes
-		if(Server()->Tick() % Server()->TickSpeed() * 900 == 0)
+		if(Server()->Tick() % (Server()->TickSpeed() * 900) == 0)
 		{
 			for(auto& p : CHouse::Data())
 				p->CheckRentExpiration();

--- a/web-tools/tools/discord/discord_bot/cogs/bridge.py
+++ b/web-tools/tools/discord/discord_bot/cogs/bridge.py
@@ -3,6 +3,8 @@ import asyncio
 import discord
 from discord.ext import commands
 import logging
+import json
+import os
 from typing import cast, Optional, Dict
 
 # Project imports
@@ -34,7 +36,85 @@ class BridgeCog(commands.Cog):
         self._monitor_task: Optional[asyncio.Task] = None
         self._first_connect_attempt = True
         self._ready_event = asyncio.Event()
+        self._muted_file = os.path.join(os.path.dirname(__file__), "..", "..", "muted_players.json")
+        self.muted_players: set = self._load_json_set(self._muted_file)
+        self._bridge_disabled_file = os.path.join(os.path.dirname(__file__), "..", "..", "bridge_disabled.json")
+        self.bridge_disabled_players: set = self._load_json_set(self._bridge_disabled_file)
 
+
+    def _load_json_set(self, filepath: str) -> set:
+        try:
+            with open(filepath, "r") as f:
+                return set(json.load(f))
+        except Exception:
+            return set()
+
+    def _save_json_set(self, filepath: str, data: set):
+        try:
+            with open(filepath, "w") as f:
+                json.dump(list(data), f, indent=2)
+        except Exception as e:
+            logger.error(f"Failed to save {os.path.basename(filepath)}: {e}")
+
+    def _has_admin_role(self, interaction: discord.Interaction) -> bool:
+        if not interaction.guild or not isinstance(interaction.user, discord.Member):
+            return False
+        admin_role_id = getattr(__import__('config'), 'ADMIN_ROLE_ID', None)
+        if admin_role_id is None:
+            return interaction.user.guild_permissions.administrator
+        return any(r.id == admin_role_id for r in interaction.user.roles)
+
+    @discord.app_commands.command(name="bridge_mute", description="[Admin] Mute a player — their in-game messages won't appear on Discord.")
+    @discord.app_commands.describe(name="Exact in-game nickname to mute")
+    async def bridge_mute(self, interaction: discord.Interaction, name: str):
+        if not self._has_admin_role(interaction):
+            await interaction.response.send_message("❌ You don't have permission to use this command.", ephemeral=True)
+            return
+        if name in self.muted_players:
+            await interaction.response.send_message(f"⚠️ `{name}` is already muted.", ephemeral=True)
+            return
+        self.muted_players.add(name)
+        self._save_json_set(self._muted_file, self.muted_players)
+        logger.info(f"Admin {interaction.user} muted player '{name}' from bridge.")
+        await interaction.response.send_message(f"🔇 `{name}` has been muted from the bridge.", ephemeral=True)
+
+    @discord.app_commands.command(name="bridge_unmute", description="[Admin] Unmute a player — their in-game messages will appear on Discord again.")
+    @discord.app_commands.describe(name="Exact in-game nickname to unmute")
+    async def bridge_unmute(self, interaction: discord.Interaction, name: str):
+        if not self._has_admin_role(interaction):
+            await interaction.response.send_message("❌ You don't have permission to use this command.", ephemeral=True)
+            return
+        if name not in self.muted_players:
+            await interaction.response.send_message(f"⚠️ `{name}` is not in the mute list.", ephemeral=True)
+            return
+        self.muted_players.discard(name)
+        self._save_json_set(self._muted_file, self.muted_players)
+        logger.info(f"Admin {interaction.user} unmuted player '{name}' from bridge.")
+        await interaction.response.send_message(f"🔊 `{name}` has been unmuted from the bridge.", ephemeral=True)
+
+    @discord.app_commands.command(name="bridge_mutelist", description="[Admin] List all players currently muted from the bridge.")
+    async def bridge_mutelist(self, interaction: discord.Interaction):
+        if not self._has_admin_role(interaction):
+            await interaction.response.send_message("❌ You don't have permission to use this command.", ephemeral=True)
+            return
+        if not self.muted_players:
+            await interaction.response.send_message("✅ No players are currently muted.", ephemeral=True)
+            return
+        sorted_list = sorted(self.muted_players)
+        chunks = []
+        current = ""
+        for p in sorted_list:
+            entry = f"`{p}`  "
+            if len(current) + len(entry) > 1800:
+                chunks.append(current)
+                current = entry
+            else:
+                current += entry
+        if current:
+            chunks.append(current)
+        await interaction.response.send_message(f"🔇 **Muted players ({len(self.muted_players)}):**\n{chunks[0]}", ephemeral=True)
+        for chunk in chunks[1:]:
+            await interaction.followup.send(chunk, ephemeral=True)
 
     @commands.Cog.listener()
     async def on_ready(self):
@@ -256,6 +336,27 @@ class BridgeCog(commands.Cog):
 
         nickname = msg["nickname"]
         message_text = msg["message"]
+
+        if nickname == '__bridge_cmd__':
+            if message_text.startswith('[BRIDGE_DISABLE] '):
+                name = message_text[len('[BRIDGE_DISABLE] '):]
+                self.bridge_disabled_players.add(name)
+                self._save_json_set(self._bridge_disabled_file, self.bridge_disabled_players)
+                logger.info(f"Bridge self-disabled by player '{name}'")
+            elif message_text.startswith('[BRIDGE_ENABLE] '):
+                name = message_text[len('[BRIDGE_ENABLE] '):]
+                self.bridge_disabled_players.discard(name)
+                self._save_json_set(self._bridge_disabled_file, self.bridge_disabled_players)
+                logger.info(f"Bridge self-enabled by player '{name}'")
+            return
+
+        if nickname in self.muted_players:
+            logger.debug(f"Bridge suppressed message from muted player '{nickname}'")
+            return
+
+        if nickname in self.bridge_disabled_players:
+            logger.debug(f"Bridge suppressed message from self-disabled player '{nickname}'")
+            return
 
         if message_text.startswith(SERVER_TAG_TEEWORLDS):
             logger.debug(f"Ignoring own bridge message from Teeworlds: {nickname}")

--- a/web-tools/tools/discord/services/teeworlds_client.py
+++ b/web-tools/tools/discord/services/teeworlds_client.py
@@ -26,6 +26,7 @@ class TeeworldsEconClient:
         escaped_discord_tag = re.escape(SERVER_TAG_TEEWORLDS)
         self.chat_pattern = re.compile(r"chat:\s*\d+:\d+:([^:]+):\s*(.*)$")
         self.system_chat_pattern = re.compile(rf"chat:\s+(\*\*\*)\s+(?!{escaped_discord_tag})(.*)")
+        self.bridge_cmd_pattern = re.compile(r"bridge:\s+(\[BRIDGE_(?:DISABLE|ENABLE)\] .+)$")
 
     @property
     def is_connected(self) -> bool:
@@ -65,6 +66,10 @@ class TeeworldsEconClient:
 
     def _parse_chat_message(self, cleaned_line: str) -> Optional[EconMessage]:
         """Parses chat-related econ output into an EconMessage."""
+        bridge_cmd_match = self.bridge_cmd_pattern.search(cleaned_line)
+        if bridge_cmd_match:
+            return EconChatMessage(type="chat", nickname="__bridge_cmd__", message=bridge_cmd_match.group(1).strip())
+
         system_chat_match = self.system_chat_pattern.search(cleaned_line)
         if system_chat_match:
             nickname = system_chat_match.group(1).strip()


### PR DESCRIPTION
Hide messages from the Discord bridge using /bridge_disable and /bridge_enable in-game.

Also cleaned up the admin mute commands — they now handle edge cases (already muted, not in list) and show a proper paginated mutelist